### PR TITLE
Allow fallback file in case folder + request path cannot be found

### DIFF
--- a/framework/router.py
+++ b/framework/router.py
@@ -39,13 +39,13 @@ class Router():
         # Add route to the route list
         self._routes.append((False, False, re.compile(regexp), function, methods))
         
-    def addStaticMapping(self, regexp, path, methods = None, fallback_file = None):
+    def addStaticMapping(self, regexp, folder, methods = None, fallback_file = None):
         """Adds a url to static files to the router. A regular expression is used to match the url.
         """
         if not methods:
             methods = httpmethods
             
-        static_handler = StaticHandler(path, fallback_file)
+        static_handler = StaticHandler(folder, fallback_file)
             
         self._routes.append((False, True, re.compile(regexp), static_handler.handle, methods))
     

--- a/framework/router.py
+++ b/framework/router.py
@@ -39,15 +39,13 @@ class Router():
         # Add route to the route list
         self._routes.append((False, False, re.compile(regexp), function, methods))
         
-    def addStaticMapping(self, regexp, folder, methods = None):
+    def addStaticMapping(self, regexp, path, methods = None, fallback_file = None):
         """Adds a url to static files to the router. A regular expression is used to match the url.
-        
-        TODO: WIP
         """
         if not methods:
             methods = httpmethods
             
-        static_handler = StaticHandler(folder)
+        static_handler = StaticHandler(path, fallback_file)
             
         self._routes.append((False, True, re.compile(regexp), static_handler.handle, methods))
     

--- a/framework/statichandler.py
+++ b/framework/statichandler.py
@@ -1,4 +1,5 @@
 import mimetypes
+from os import path
 
 from framework.httpexceptions import HttpNotFoundException
 
@@ -6,10 +7,11 @@ class StaticHandler():
     """StaticHandler handles request to static files and serves these files.
     """
     
-    def __init__(self, folder):
+    def __init__(self, folder, fallback_file = None):
         """Create new StaticHandler, point it to the base folder to search files in
         """
         self._folder = folder
+        self._fallback_file = fallback_file
         
         # If the path doesn't end with an "/" add one.
         if not self._folder.endswith("/"):
@@ -22,10 +24,15 @@ class StaticHandler():
         
         try:
             # Try to open the file in binary mode
-            file = open(self._folder + request.path_info, 'rb')
+            if self._fallback_file and not path.isfile(self._folder + request.path_info):
+                full_path = self._folder + self._fallback_file
+            else:
+                full_path = self._folder + request.path_info
+
+            file = open(full_path, 'rb')
             
             # Try to guess the content type
-            response.content_type = mimetypes.guess_type(self._folder + request.path_info)[0]
+            response.content_type = mimetypes.guess_type(full_path)[0]
 
             # Set a default content type if no guess was found
             if not response.content_type:


### PR DESCRIPTION
See also: https://angular.io/guide/deployment#routed-apps-must-fallback-to-indexhtml
Routed app should fallback to index.html in case routes cannot be found. This
change allows that without breaking existing static handler instances.